### PR TITLE
Revert retry to 1 as default

### DIFF
--- a/sense/common.py
+++ b/sense/common.py
@@ -76,5 +76,5 @@ def getHTTPTimeout():
     return int(os.environ.get('SENSE_TIMEOUT', 300))
 
 def getHTTPRetries():
-    """Get HTTP Retries from env or default to 3"""
-    return int(os.environ.get('SENSE_RETRIES', 3))
+    """Get HTTP Retries from env or default to 1"""
+    return int(os.environ.get('SENSE_RETRIES', 1))


### PR DESCRIPTION
As discussed with Xi over Slack, we need to redesign all retry logic based on API calls, and not do this blindly.